### PR TITLE
Codecov setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ env:
   global:
   - PATH=./racket/bin:$PATH
   matrix:
-  - TEST_TYPE=tests
+  # - TEST_TYPE=tests
   - TEST_TYPE=coverage
-  - TEST_TYPE=translate
-  - TEST_TYPE=translate_nojit_and_racket_tests
+  # - TEST_TYPE=translate
+  # - TEST_TYPE=translate_nojit_and_racket_tests
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,24 +15,12 @@ env:
   matrix:
   - TEST_TYPE=tests
   - TEST_TYPE=coverage
-  - TEST_TYPE=coverage_push
   - TEST_TYPE=translate
   - TEST_TYPE=translate_nojit_and_racket_tests
 matrix:
   fast_finish: true
   allow_failures:
   - env: TEST_TYPE=coverage
-  - env: TEST_TYPE=coverage_push
 before_install: ./travis.sh prepare
 install: ./travis.sh install
 script: ./travis.sh test $TEST_TYPE
-deploy:
-  provider: heroku
-  api_key:
-    secure: V30lYs1EyPT4BiAoAg0tSq8IJqbquGWL2kVcbc4DqpOmD5vTq6jGsIaeJcPB3hn6cEXfdiFVj/CxJvE1sziATsgJTyvx55gfoT3U3Znij/A4CUQKEgrxUQ44Q2RsiuixDKKYQjKxanTAvbKFOov6PlwSiNHx15p47yoWtB6C1tc=
-  app: pycket-cover
-  skip_cleanup: true
-  on:
-      condition: "$TEST_TYPE = coverage_push"
-before_deploy: ./travis.sh prepare_coverage_deployment
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ env:
   global:
   - PATH=./racket/bin:$PATH
   matrix:
-  # - TEST_TYPE=tests
+  - TEST_TYPE=tests
   - TEST_TYPE=coverage
-  # - TEST_TYPE=translate
-  # - TEST_TYPE=translate_nojit_and_racket_tests
+  - TEST_TYPE=translate
+  - TEST_TYPE=translate_nojit_and_racket_tests
 matrix:
   fast_finish: true
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/samth/pycket.png?branch=master)](https://travis-ci.org/samth/pycket)
+[![codecov.io](https://codecov.io/github/samth/pycket/coverage.svg?branch=master)](https://codecov.io/github/samth/pycket?branch=master)
 
 A Racket/Scheme implementation using RPython. It adds a JIT.
 

--- a/travis.sh
+++ b/travis.sh
@@ -81,7 +81,8 @@ do_tests() {
 }
 
 do_coverage() {
-  set +ex
+  set +e
+  set -x
   rm -rf ../pypy/*pytest*
   py.test --assert=reinterp -rf -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'

--- a/travis.sh
+++ b/travis.sh
@@ -82,7 +82,8 @@ do_tests() {
 
 do_coverage() {
   set +e
-  py.test -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
+  rm -rf ../pypy/*pytest*
+  py.test --assert=reinterp -rf -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'
   coverage report -i --fail-under=80 --omit='pycket/test/*','*__init__*'
   codecov --no-fail -X gcov
@@ -134,8 +135,8 @@ do_translate_nojit_and_racket_tests() {
 ############################################################
 
 install_deps() {
-  pip install pytest-xdist codecov pytest-cov cov-core || \
-      pip install --user pytest-xdist codecov pytest-cov cov-core
+  pip install pytest-xdist codecov pytest-cov || \
+      pip install --user pytest-xdist codecov pytest-cov
 }
 
 install_racket() {

--- a/travis.sh
+++ b/travis.sh
@@ -6,6 +6,8 @@
 DLHOST=utah
 RACKET_VERSION=current
 
+COVERAGE_TESTSUITE='not test_larger'
+
 #
 
 set -e
@@ -20,7 +22,7 @@ command is one of
   install       Install direct prerequisites
   test <what>   Test (may include building, testing, coverage)
         tests         Run pytest tests
-        coverage      Run pytest coverage report
+        coverage      Run pytest coverage report and upload
         translate     Translate pycket with jit
         translate_nojit_and_racket_tests
                      Translate pycket without jit and run racket test
@@ -72,41 +74,20 @@ fi
 
 
 
-COVERAGE_TESTSUITE='not test_larger'
-COVERAGE_HTML_DIR=pycket/test/coverage_report
 
 ############### test targets ################################
 do_tests() {
   py.test -n 3 --duration 20 pycket
 }
 
-
 do_coverage() {
+  set +e
   py.test -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'
   coverage report -i --fail-under=80 --omit='pycket/test/*','*__init__*'
+  codecov --no-fail -X gcov
 }
 
-do_coverage_push() {
-  # always succeed to allow coverage push on test failure
-  py.test -n 3 -k "$COVERAGE_TESTSUITE" \
-          --cov . --cov-report=html pycket || true
-  # but fail if the report is not there
-  [ -f .coverage -a \
-       -d "$COVERAGE_HTML_DIR" -a \
-       -f "$COVERAGE_HTML_DIR/index.html" ]
-}
-
-
-do_prepare_coverage_deployment() {
-  [ -f .coverage ] || exit 1
-  [ -d $COVERAGE_HTML_DIR ] || exit 1
-  mv $COVERAGE_HTML_DIR /tmp
-  rm -rf ./*
-  cp -a "/tmp/$(basename "$COVERAGE_HTML_DIR")/"* .
-  echo "web: vendor/bin/heroku-php-nginx" > Procfile
-  echo '{}' > composer.json
-}
 
 do_translate() {
   ../pypy/rpython/bin/rpython -Ojit --batch targetpycket.py
@@ -153,8 +134,8 @@ do_translate_nojit_and_racket_tests() {
 ############################################################
 
 install_deps() {
-  pip install pytest-xdist 'pytest-cov~=1.8.1' cov-core 'coverage<4.0' || \
-      pip install --user pytest-xdist 'pytest-cov~=1.8.1' cov-core 'coverage<4.0'
+  pip install pytest-xdist codecov pytest-cov || \
+      pip install --user pytest-xdist codecov pytest-cov
 }
 
 install_racket() {
@@ -262,9 +243,6 @@ case "$COMMAND" in
     fi
     echo "Running $TEST_TYPE"
     do_$TEST_TYPE
-    ;;
-  prepare_coverage_deployment)
-    do_prepare_coverage_deployment
     ;;
   *)
     _help

--- a/travis.sh
+++ b/travis.sh
@@ -86,9 +86,10 @@ do_coverage() {
   # So remove them on the CI.
   rm -rf ../pypy/*pytest*
   py.test --assert=plain -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
+  codecov --no-fail -X gcov
+  set -e
   echo '>> Testing whether coverage is over 80%'
   coverage report -i --fail-under=80 --omit='pycket/test/*','*__init__*'
-  codecov --no-fail -X gcov
 }
 
 

--- a/travis.sh
+++ b/travis.sh
@@ -84,7 +84,7 @@ do_coverage() {
   set +e
   set -x
   rm -rf ../pypy/*pytest*
-  py.test --assert=reinterp -rf -v -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
+  py.test --assert=plain -v -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'
   coverage report -i --fail-under=80 --omit='pycket/test/*','*__init__*'
   codecov --no-fail -X gcov

--- a/travis.sh
+++ b/travis.sh
@@ -136,8 +136,10 @@ do_translate_nojit_and_racket_tests() {
 ############################################################
 
 install_deps() {
-  pip install pytest-xdist codecov pytest-cov || \
-      pip install --user pytest-xdist codecov pytest-cov
+  pip install pytest-xdist || pip install --user pytest-xdist
+  if [ $TEST_TYPE = 'coverage' ]; then
+    pip install codecov pytest-cov || pip install codecov pytest-cov
+  fi
 }
 
 install_racket() {

--- a/travis.sh
+++ b/travis.sh
@@ -82,6 +82,8 @@ do_tests() {
 
 do_coverage() {
   set +e
+  # PyPy's pytest modifications clash with recent pytest-cov/coverage releases
+  # So remove them on the CI.
   rm -rf ../pypy/*pytest*
   py.test --assert=plain -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'

--- a/travis.sh
+++ b/travis.sh
@@ -6,7 +6,7 @@
 DLHOST=utah
 RACKET_VERSION=current
 
-COVERAGE_TESTSUITE='not test_larger'
+COVERAGE_TESTSUITE='not (test_larger or test_contract_structs)'
 
 #
 

--- a/travis.sh
+++ b/travis.sh
@@ -81,7 +81,7 @@ do_tests() {
 }
 
 do_coverage() {
-  set +e
+  set +ex
   rm -rf ../pypy/*pytest*
   py.test --assert=reinterp -rf -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'

--- a/travis.sh
+++ b/travis.sh
@@ -82,9 +82,8 @@ do_tests() {
 
 do_coverage() {
   set +e
-  set -x
   rm -rf ../pypy/*pytest*
-  py.test --assert=plain -v -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
+  py.test --assert=plain -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'
   coverage report -i --fail-under=80 --omit='pycket/test/*','*__init__*'
   codecov --no-fail -X gcov

--- a/travis.sh
+++ b/travis.sh
@@ -6,7 +6,7 @@
 DLHOST=utah
 RACKET_VERSION=current
 
-COVERAGE_TESTSUITE='not (test_larger or test_contract_structs)'
+COVERAGE_TESTSUITE='not (test_larger or test_contract_structs or test_quote_syntax_expansion)'
 
 #
 

--- a/travis.sh
+++ b/travis.sh
@@ -84,7 +84,7 @@ do_coverage() {
   set +e
   set -x
   rm -rf ../pypy/*pytest*
-  py.test --assert=reinterp -rf -n 3 -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
+  py.test --assert=reinterp -rf -v -k "$COVERAGE_TESTSUITE" --cov . --cov-report=term pycket
   echo '>> Testing whether coverage is over 80%'
   coverage report -i --fail-under=80 --omit='pycket/test/*','*__init__*'
   codecov --no-fail -X gcov

--- a/travis.sh
+++ b/travis.sh
@@ -134,8 +134,8 @@ do_translate_nojit_and_racket_tests() {
 ############################################################
 
 install_deps() {
-  pip install pytest-xdist codecov pytest-cov || \
-      pip install --user pytest-xdist codecov pytest-cov
+  pip install pytest-xdist codecov pytest-cov cov-core || \
+      pip install --user pytest-xdist codecov pytest-cov cov-core
 }
 
 install_racket() {


### PR DESCRIPTION
Dump manual coverage report generation and use https://codecov.io/.

 - Removes Heroku deployment
 - Removes one matrix build
 - Exclude two more tests (`test_contract_structs`, `test_quote_syntax_expansion`) that are too stressful for the coverage analyzer on Travis