### PR TITLE
Don't crash when peeking unicode characters from port

### DIFF
--- a/pycket/prims/input_output.py
+++ b/pycket/prims/input_output.py
@@ -316,12 +316,17 @@ def do_read_one(w_port, as_bytes, peek, env, cont):
 
 @expose("read-char", [default(values.W_InputPort, None)], simple=False)
 def read_char(w_port, env, cont):
-    return do_read_one(w_port, False, False, env, cont)
+    try:
+        return do_read_one(w_port, False, False, env, cont)
+    except UnicodeDecodeError:
+        raise SchemeException("read-char: string is not a well-formed UTF-8 encoding")
 
 @expose("read-byte", [default(values.W_InputPort, None)], simple=False)
 def read_byte(w_port, env, cont):
-    return do_read_one(w_port, True, False, env, cont)
-
+    try:
+        return do_read_one(w_port, True, False, env, cont)
+    except UnicodeDecodeError:
+        raise SchemeException("read-byte: string is not a well-formed UTF-8 encoding")
 
 def do_peek(w_port, as_bytes, skip, env, cont):
     if skip == 0:
@@ -338,13 +343,19 @@ def do_peek(w_port, as_bytes, skip, env, cont):
                       default(values.W_Fixnum, values.W_Fixnum.ZERO)],
                     simple=False)
 def peek_char(w_port, w_skip, env, cont):
-    return do_peek(w_port, False, w_skip.value, env, cont)
+    try:
+        return do_peek(w_port, False, w_skip.value, env, cont)
+    except UnicodeDecodeError:
+        raise SchemeException("peek-char: string is not a well-formed UTF-8 encoding")
 
 @expose("peek-byte", [default(values.W_InputPort, None),
                       default(values.W_Fixnum, values.W_Fixnum.ZERO)],
                     simple=False)
 def peek_byte(w_port, w_skip, env, cont):
-    return do_peek(w_port, True, w_skip.value, env, cont)
+    try:
+        return do_peek(w_port, True, w_skip.value, env, cont)
+    except UnicodeDecodeError:
+        raise SchemeException("peek-byte: string is not a well-formed UTF-8 encoding")
 
 w_text_sym   = values.W_Symbol.make("text")
 w_binary_sym = values.W_Symbol.make("binary")

--- a/pycket/prims/input_output.py
+++ b/pycket/prims/input_output.py
@@ -304,7 +304,12 @@ def do_read_one(w_port, as_bytes, peek, env, cont):
     else:
         # hmpf, poking around in internals
         needed = runicode.utf8_code_length[i]
-        c += w_port.read(needed - 1)
+        if peek:
+            old = w_port.tell()
+            c = w_port.read(needed)
+            w_port.seek(old)
+        else:
+            c += w_port.read(needed - 1)
         c = c.decode("utf-8")
         assert len(c) == 1
         return return_value(values.W_Character(c[0]), env, cont)

--- a/pycket/test/test_prims.py
+++ b/pycket/test/test_prims.py
@@ -636,6 +636,19 @@ def test_port_read_peek(doctest):
     101
     > (read-byte bp)
     40
+    > (define usp (open-input-string "\u4F60\u597D,\u4E16\u754C"))
+    > (peek-byte usp)
+    228
+    > (peek-char usp)
+    #\u4F60
+    > (peek-char usp)
+    #\u4F60
+    > (read-char usp)
+    #\u4F60
+    > (read-char usp)
+    #\u597D
+    > (read-char usp)
+    #\,
     """
 
 def test_peek_bug(tmpdir):


### PR DESCRIPTION
peek-char fails when given a unicode string, as in the part where code point is checked we still have to read all bytes as pointer in port is not incremented for read().  

Following is an example program to compare between Racket and Pycket.

```
#lang pycket

(define f  (open-input-string "你好,世界"))

(print (string-length "你好,世界"))
(print  (peek-char f))
(print  (peek-char f))
(print  (peek-char f))
(print  (read-char f))
(print  (read-char f))
```
